### PR TITLE
add row-wise splitting to recover convex matrices

### DIFF
--- a/distributed_shampoo/fsdp_shampoo.py
+++ b/distributed_shampoo/fsdp_shampoo.py
@@ -24,6 +24,7 @@ from distributed_shampoo.shampoo_utils import (
     LargeDimMethod,
     Preconditioner,
     ShampooPreconditioner,
+    SplitShampooPreconditioner,
 )
 
 logger = logging.getLogger(__name__)
@@ -193,6 +194,7 @@ class FSDPShampoo(torch.optim.Optimizer):
     def __init__(
         self,
         params,
+        param_metadata: Dict[torch.nn.Parameter, Tuple],
         lr: float = 1e-2,
         betas: Tuple[float, float] = (0.9, 1.0),
         epsilon: float = 1e-12,
@@ -308,6 +310,7 @@ class FSDPShampoo(torch.optim.Optimizer):
         )
 
         # Initialize algorithm-related fields.
+        self._param_metadata = param_metadata
         self._max_preconditioner_dim = max_preconditioner_dim
         self._precondition_frequency = precondition_frequency
         self._exponent_override = exponent_override
@@ -360,127 +363,36 @@ class FSDPShampoo(torch.optim.Optimizer):
         # current workaround for group_source_rank
         # TODO: try to keep dist_group information
         self._dist_group = None
-        group_rank = 0
-        buffer_ranks = None
 
         for group in self.param_groups:
-            preconditioner_count = 0
             for idx, p in enumerate(group[PARAMS]):
                 # skip parameters not on worker
                 if p.numel() == 0:
                     continue
 
                 state = self.state[p]
-                dims = torch.as_tensor(p.shape)
                 state[STEP] = torch.tensor(0)
 
-                # Blocks the tensor and applies Shampoo to each block, with block
-                # size equal to the max_preconditioner_dim; see feature above.
-                if self._large_dim_method == LargeDimMethod.BLOCKING:
-                    state[PRECONDITIONERS] = BlockShampooPreconditioner(
-                        p,
-                        beta2=group[BETAS][1],
-                        epsilon=group[EPSILON],
-                        exponent_override=self._exponent_override,
-                        exponent_multiplier=self._exponent_multiplier,
-                        use_bias_correction=self._use_bias_correction,
-                        block_size=self._max_preconditioner_dim,
-                        dtype=self._preconditioner_dtype,
-                        idx=idx,
-                        use_merge_dims=self._use_merge_dims,
-                        start_preconditioning_step=self._start_preconditioning_step,
-                        grafting_type=self._grafting_type,
-                        grafting_beta2=self._grafting_beta2,
-                        grafting_epsilon=self._grafting_epsilon,
-                        group=self._dist_group,
-                        dist_buffer_ranks=buffer_ranks,
-                        dist_buffer_index=preconditioner_count,
-                        use_protected_eigh=self._use_protected_eigh,
-                        use_dtensor=self._use_dtensor,
-                    )
-                    preconditioner_count += state[PRECONDITIONERS].num_preconditioners()
-
-                # Uses Adagrad preconditioner if any dimension is larger than
-                # the max_preconditioner_dim; see features above.
-                elif self._large_dim_method == LargeDimMethod.ADAGRAD:
-                    dist_buffer, group_source_rank = (
-                        buffer_ranks[preconditioner_count]
-                        if buffer_ranks
-                        else (None, 0)
-                    )
-                    preconditioner_count += 1
-                    state[PRECONDITIONERS] = (
-                        AdagradPreconditioner(
-                            p,
-                            beta2=group[BETAS][1],
-                            epsilon=group[EPSILON],
-                            use_bias_correction=self._use_bias_correction,
-                            idx=idx,
-                            group=self._dist_group,
-                            group_source_rank=group_source_rank,
-                            dist_buffer=dist_buffer,
-                            use_dtensor=self._use_dtensor,
-                        )
-                        if torch.any(dims > self._max_preconditioner_dim)
-                        else ShampooPreconditioner(
-                            p,
-                            beta2=group[BETAS][1],
-                            epsilon=group[EPSILON],
-                            exponent_override=self._exponent_override,
-                            exponent_multiplier=self._exponent_multiplier,
-                            use_bias_correction=self._use_bias_correction,
-                            diagonal_threshold=self._max_preconditioner_dim,
-                            dtype=self._preconditioner_dtype,
-                            idx=idx,
-                            start_preconditioning_step=self._start_preconditioning_step,
-                            grafting_type=self._grafting_type,
-                            grafting_beta2=self._grafting_beta2,
-                            grafting_epsilon=self._grafting_epsilon,
-                            group=self._dist_group,
-                            group_source_rank=group_source_rank,
-                            dist_buffer=dist_buffer,
-                            use_protected_eigh=self._use_protected_eigh,
-                            use_dtensor=self._use_dtensor,
-                        )
-                    )
-
-                # Uses diagonal Shampoo preconditioner in place of full Shampoo
-                # preconditioner if dimension is larger than max_preconditioner_dim; see feature
-                # above.
-                elif self._large_dim_method == LargeDimMethod.DIAGONAL:
-                    dist_buffer, group_source_rank = (
-                        buffer_ranks[preconditioner_count]
-                        if buffer_ranks
-                        else (None, 0)
-                    )
-                    preconditioner_count += 1
-                    state[PRECONDITIONERS] = ShampooPreconditioner(
-                        p,
-                        beta2=group[BETAS][1],
-                        epsilon=group[EPSILON],
-                        exponent_override=self._exponent_override,
-                        exponent_multiplier=self._exponent_multiplier,
-                        use_bias_correction=self._use_bias_correction,
-                        diagonal_threshold=self._max_preconditioner_dim,
-                        dtype=self._preconditioner_dtype,
-                        idx=idx,
-                        start_preconditioning_step=self._start_preconditioning_step,
-                        grafting_type=self._grafting_type,
-                        grafting_beta2=self._grafting_beta2,
-                        grafting_epsilon=self._grafting_epsilon,
-                        group=self._dist_group,
-                        group_source_rank=group_source_rank,
-                        dist_buffer=dist_buffer,
-                        use_protected_eigh=self._use_protected_eigh,
-                        use_dtensor=self._use_dtensor,
-                    )
-
-                else:
-                    raise ValueError(
-                        "Large dim method "
-                        + str(self._large_dim_method)
-                        + " is not implemented!"
-                    )
+                state[PRECONDITIONERS] = SplitShampooPreconditioner(
+                    p,
+                    self._param_metadata[p],
+                    large_dim_method=self._large_dim_method,
+                    beta2=group[BETAS][1],
+                    epsilon=group[EPSILON],
+                    exponent_override=self._exponent_override,
+                    exponent_multiplier=self._exponent_multiplier,
+                    use_bias_correction=self._use_bias_correction,
+                    max_preconditioner_dim=self._max_preconditioner_dim,
+                    dtype=self._preconditioner_dtype,
+                    idx=idx,
+                    use_merge_dims=self._use_merge_dims,
+                    start_preconditioning_step=self._start_preconditioning_step,
+                    grafting_type=self._grafting_type,
+                    grafting_beta2=self._grafting_beta2,
+                    grafting_epsilon=self._grafting_epsilon,
+                    use_protected_eigh=self._use_protected_eigh,
+                    use_dtensor=self._use_dtensor,
+                )
 
                 # Count parameters from preconditioners for logging purposes.
                 self._parameter_count += state[PRECONDITIONERS].parameter_count
@@ -504,7 +416,11 @@ class FSDPShampoo(torch.optim.Optimizer):
 
                 if isinstance(
                     state[PRECONDITIONERS],
-                    (ShampooPreconditioner, BlockShampooPreconditioner),
+                    (
+                        ShampooPreconditioner,
+                        BlockShampooPreconditioner,
+                        SplitShampooPreconditioner,
+                    ),
                 ):
                     state[PRECONDITIONERS].compute_root_inverse()
 
@@ -538,7 +454,11 @@ class FSDPShampoo(torch.optim.Optimizer):
 
                 if isinstance(
                     state[PRECONDITIONERS],
-                    (ShampooPreconditioner, BlockShampooPreconditioner),
+                    (
+                        ShampooPreconditioner,
+                        BlockShampooPreconditioner,
+                        SplitShampooPreconditioner,
+                    ),
                 ):
                     relative_error, relative_residual = state[
                         PRECONDITIONERS
@@ -579,7 +499,7 @@ class FSDPShampoo(torch.optim.Optimizer):
 
                 grad = p.grad
                 state = self.state[p]
-                if grad is None or not state[PRECONDITIONERS].on_source_rank:
+                if grad is None:
                     continue
 
                 weight_decay = group[WEIGHT_DECAY]
@@ -640,9 +560,9 @@ class FSDPShampoo(torch.optim.Optimizer):
                 )
 
             # Generate split lists.
-            split_params.extend(state[PRECONDITIONERS].combine_and_split_dims(p))
+            split_params.extend(state[PRECONDITIONERS].apply_split(p, full_split=True))
             split_momentum_directions.extend(
-                state[PRECONDITIONERS].combine_and_split_dims(state[MOMENTUM])
+                state[PRECONDITIONERS].apply_split(state[MOMENTUM], full_split=True)
                 if momentum_param != 0.0
                 else []
             )
@@ -718,7 +638,7 @@ class FSDPShampoo(torch.optim.Optimizer):
 
             for p in group[PARAMS]:
                 state = self.state[p]
-                if p.grad is None or not state[PRECONDITIONERS].on_source_rank:
+                if p.numel() == 0 or p.grad is None:
                     continue
 
                 # Incorporate first-moment or filtered gradient estimation.

--- a/distributed_shampoo/tests/shampoo_utils_test.py
+++ b/distributed_shampoo/tests/shampoo_utils_test.py
@@ -27,6 +27,8 @@ except ImportError:
 
 import unittest.mock as mock
 
+from torch.testing._internal.common_distributed import spawn_threads_and_init_comms
+
 from distributed_shampoo.shampoo_dist_utils import use_local_tensor
 from distributed_shampoo.shampoo_utils import (
     AdagradGrafting,
@@ -35,6 +37,7 @@ from distributed_shampoo.shampoo_utils import (
     AdamGrafting,
     AdamNormalizedGrafting,
     BlockShampooPreconditioner,
+    convex_split,
     DistributedPreconditioner,
     GraftingType,
     merge_small_dims,
@@ -47,7 +50,6 @@ from distributed_shampoo.shampoo_utils import (
     SGDGrafting,
     ShampooPreconditioner,
 )
-from torch.testing._internal.common_distributed import spawn_threads_and_init_comms
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -159,6 +161,110 @@ class MultiDimCatTest(unittest.TestCase):
             torch.tensor([[[23]], [[29]]]),
         ]
         self._test_multi_dim_cat(grad, num_splits, split_grad)
+
+
+class ConvexSplitTest(unittest.TestCase):
+    def _test_convex_split(self, tensor, split_tensors, start_idx, end_idx) -> None:
+        for idx, t in enumerate(
+            convex_split(
+                tensor.flatten()[start_idx : end_idx + 1],
+                tensor.size(),
+                start_idx,
+                end_idx,
+            )
+        ):
+            with self.subTest(f"Test with idx = {idx}"):
+                torch.testing.assert_close(split_tensors[idx], t)
+
+    def test_convex_split_for_one_dim(self) -> None:
+        tensor = torch.arange(10)
+        self._test_convex_split(tensor, [tensor], 0, 9)
+
+        split_tensors = [torch.arange(6) + 2]
+        self._test_convex_split(tensor, split_tensors, 2, 7)
+
+    def test_convex_split_for_two_dim(self) -> None:
+        tensor = torch.arange(48).reshape(6, 8)
+        self._test_convex_split(tensor, [tensor], 0, 47)
+
+        split_tensors = [
+            torch.tensor([8, 9, 10]),
+            torch.arange(8).reshape(1, 8),
+        ]
+        self._test_convex_split(tensor, split_tensors, 0, 10)
+
+        split_tensors = [
+            torch.tensor([11, 12, 13, 14, 15]),
+            torch.arange(32).reshape(4, 8) + 16,
+        ]
+        self._test_convex_split(tensor, split_tensors, 11, 47)
+
+        split_tensors = [
+            torch.tensor([11, 12, 13, 14, 15]),
+            torch.tensor([24, 25, 26, 27, 28, 29]),
+            torch.arange(8).reshape(1, 8) + 16,
+        ]
+        self._test_convex_split(tensor, split_tensors, 11, 29)
+
+        split_tensors = [
+            torch.tensor([11, 12, 13, 14, 15]),
+            torch.tensor([16]),
+        ]
+        self._test_convex_split(tensor, split_tensors, 11, 16)
+
+    def test_convex_split_for_three_dim(self) -> None:
+        tensor = torch.arange(27).reshape(3, 3, 3)
+        self._test_convex_split(tensor, [tensor], 0, 26)
+
+        split_tensors = [
+            torch.tensor([9, 10]),
+            torch.arange(9).reshape(3, 3),
+        ]
+        self._test_convex_split(tensor, split_tensors, 0, 10)
+
+        split_tensors = [
+            torch.tensor([[21, 22, 23], [24, 25, 26]]),
+        ]
+        self._test_convex_split(tensor, split_tensors, 21, 26)
+
+        split_tensors = [
+            torch.arange(9).reshape(3, 3) + 9,
+        ]
+        self._test_convex_split(tensor, split_tensors, 9, 17)
+
+        split_tensors = [
+            torch.tensor([8]),
+            torch.tensor([18]),
+            torch.arange(9).reshape(3, 3) + 9,
+        ]
+        self._test_convex_split(tensor, split_tensors, 8, 18)
+
+    def test_convex_split_for_four_dim(self) -> None:
+        tensor = torch.arange(81).reshape(3, 3, 3, 3)
+        self._test_convex_split(tensor, [tensor], 0, 80)
+
+        split_tensors = [
+            torch.tensor([9, 10]),
+            torch.arange(9).reshape(3, 3),
+        ]
+        self._test_convex_split(tensor, split_tensors, 0, 10)
+
+        split_tensors = [
+            torch.tensor([[21, 22, 23], [24, 25, 26]]),
+        ]
+        self._test_convex_split(tensor, split_tensors, 21, 26)
+
+        split_tensors = [
+            torch.arange(9).reshape(3, 3) + 9,
+        ]
+        self._test_convex_split(tensor, split_tensors, 9, 17)
+
+        split_tensors = [
+            torch.tensor([8]),
+            torch.tensor([18]),
+            torch.arange(9).reshape(3, 3) + 9,
+        ]
+        self._test_convex_split(tensor, split_tensors, 8, 18)
 
 
 class PreconditionerTest(unittest.TestCase):


### PR DESCRIPTION
Create function to compute a row-wise convex split of a given non-convex shard (with unit tests). Incorporate function into FSDP Shampoo so that when sharding strategy is set to FULL_SHARD, Shampoo will be computed for each of the matrices in the split instead of blocked full-matrix Adagrad.

(After merging with the main branch the commits got copied for some reason, not sure why. But it doesn't appear to affect viewing the code.)